### PR TITLE
Package content exposition

### DIFF
--- a/demos/demo_pathlib_to_str.py
+++ b/demos/demo_pathlib_to_str.py
@@ -16,7 +16,7 @@ def _sys_path_contains(dir_path):
 	return dir_path in sys.path
 
 
-print("sys.path\n" + "\n".join(sys.path))
+print("sys.path:\n" + "\n".join(sys.path))
 
 print("\nAre these paths in sys.path?")
 for dir_path in sys.argv[1:]:

--- a/strath/__init__.py
+++ b/strath/__init__.py
@@ -1,8 +1,9 @@
-__all__ = [
-	"ensure_path_is_pathlib",
-	"ensure_path_is_str"
-]
-
 from .strath import\
 	ensure_path_is_pathlib,\
 	ensure_path_is_str
+
+
+__all__ = [
+	ensure_path_is_pathlib.__name__,
+	ensure_path_is_str.__name__
+]

--- a/strath/__init__.py
+++ b/strath/__init__.py
@@ -1,3 +1,8 @@
-from ._strath import\
+__all__ = [
+	"ensure_path_is_pathlib",
+	"ensure_path_is_str"
+]
+
+from .strath import\
 	ensure_path_is_pathlib,\
 	ensure_path_is_str

--- a/strath/strath.py
+++ b/strath/strath.py
@@ -40,7 +40,7 @@ def ensure_path_is_pathlib(some_path, is_none_allowed):
 	Raises:
 		TypeError: if some_path is of a wrong type.
 	"""
-	if isinstance(some_path, Path) or is_none_allowed and some_path is None:
+	if isinstance(some_path, Path) or (is_none_allowed and some_path is None):
 		return some_path
 	elif isinstance(some_path, str):
 		return Path(some_path)
@@ -71,7 +71,7 @@ def ensure_path_is_str(some_path, is_none_allowed):
 	Raises:
 		TypeError: if some_path is of a wrong type.
 	"""
-	if isinstance(some_path, str) or is_none_allowed and some_path is None:
+	if isinstance(some_path, str) or (is_none_allowed and some_path is None):
 		return some_path
 	elif isinstance(some_path, Path):
 		return str(some_path)

--- a/strath/strath.py
+++ b/strath/strath.py
@@ -1,7 +1,4 @@
-__all__ = [
-	"ensure_path_is_pathlib",
-	"ensure_path_is_str"
-]
+# __all__ declared at the module's end
 
 from pathlib import Path
 
@@ -77,3 +74,9 @@ def ensure_path_is_str(some_path, is_none_allowed):
 		return str(some_path)
 	else:
 		_raise_type_error(is_none_allowed)
+
+
+__all__ = [
+	ensure_path_is_pathlib.__name__,
+	ensure_path_is_str.__name__
+]

--- a/strath/strath.py
+++ b/strath/strath.py
@@ -1,3 +1,8 @@
+__all__ = [
+	"ensure_path_is_pathlib",
+	"ensure_path_is_str"
+]
+
 from pathlib import Path
 
 


### PR DESCRIPTION
* The module and the package declare `__all__`.
* `__all__` filled with attribute `.__name__`: less error-prone.
* Leading underscore removed from module `strath`.