### PR TITLE
[11] Repository's root at index 0 in `sys.path`

### DIFF
--- a/demos/demo_fnc_calls.py
+++ b/demos/demo_fnc_calls.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 
 repo_root = str(Path(__file__).resolve().parents[1])
-sys.path.append(repo_root)
+sys.path.insert(0, repo_root)
 from strath import\
 	ensure_path_is_pathlib,\
 	ensure_path_is_str

--- a/demos/demo_pathlib_to_str.py
+++ b/demos/demo_pathlib_to_str.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 
 repo_root = str(Path(__file__).resolve().parents[1])
-sys.path.append(repo_root)
+sys.path.insert(0, repo_root)
 from strath import ensure_path_is_str
 sys.path.remove(repo_root)
 del repo_root

--- a/demos/demo_str_to_pathlib.py
+++ b/demos/demo_str_to_pathlib.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 
 repo_root = str(Path(__file__).resolve().parents[1])
-sys.path.append(repo_root)
+sys.path.insert(0, repo_root)
 from strath import ensure_path_is_pathlib
 sys.path.remove(repo_root)
 del repo_root

--- a/strath/strath.py
+++ b/strath/strath.py
@@ -44,7 +44,6 @@ def ensure_path_is_pathlib(
 		some_path = Path(some_path)
 
 	elif some_path is None:
-
 		if not is_none_allowed:
 			_raise_type_error(is_none_allowed)
 
@@ -84,7 +83,6 @@ def ensure_path_is_str(
 		some_path = str(some_path)
 
 	elif some_path is None:
-
 		if not is_none_allowed:
 			_raise_type_error(is_none_allowed)
 

--- a/tests/test_strath.py
+++ b/tests/test_strath.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 
 repo_root = str(Path(__file__).resolve().parents[1])
-sys.path.append(repo_root)
+sys.path.insert(0, repo_root)
 from strath import\
 	ensure_path_is_pathlib,\
 	ensure_path_is_str


### PR DESCRIPTION
The path is inserted at index 0 in the tests and the demos.

Close #11