### PR TITLE
[15] Type annotations revised

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cette bibliothèque aide à assurer qu'un chemin de fichier soit de type `str` o
 
 En Python, il est possible de représenter des chemins de fichier au moyen de
 chaînes de caractères (`str`) ou d'instances de `pathlib.Path`. Ces types
-étant employés de façons fort différentes, un développeur peut avoir besoin de
+étant employés de façons fort différentes, un programmeur peut avoir besoin de
 vérifier le type des objets et d'effectuer des conversions.
 
 La bibliothèque `strath` permet de faire ces deux tâches en un seul appel de
@@ -93,7 +93,7 @@ This library helps ensuring that a file path is of type `str` or
 
 In Python, it is possible to represent file paths with character strings
 (`str`) or `pathlib.Path` instances. Since these types are used in very
-different ways, a developer might need to verify the objects' type and to
+different ways, a programmer might need to verify the objects' type and to
 perform conversions.
 
 Library `strath` allows to do both tasks with one function call.

--- a/README.md
+++ b/README.md
@@ -47,22 +47,22 @@ dans le dépôt de code source.
 
 ### Démos
 
-`demos/demo1_fnc_calls.py` contient des exemples d'appel des fonctions de
-`strath`.
+Dans `demos/demo1_fnc_calls.py`, les fonctions convertissent des chemins et
+traitent des valeurs `None`.
 
 ```
 python demos/demo1_fnc_calls.py
 ```
 
-`demos/demo2_str_to_pathlib.py` contient une fonction qui utilise une instance
-de `pathlib.Path`, mais ne connaît pas le type de son argument.
+Dans `demos/demo2_str_to_pathlib.py`, une fonction vérifie que le chemin est
+une instance de `pathlib.Path`.
 
 ```
 python demos/demo2_str_to_pathlib.py demos/the_planets.txt
 ```
 
-`demos/demo3_pathlib_to_str.py` contient une fonction qui utilise une chaîne de
-caractères, mais ne connaît pas le type de son argument.
+Dans `demos/demo3_pathlib_to_str.py`, une fonction vérifie que le chemin est
+une chaîne de caractères.
 
 ```
 python demos/demo3_pathlib_to_str.py .. . .github/workflows demos strath tests
@@ -132,21 +132,22 @@ source code repository.
 
 ### Demos
 
-`demos/demo1_fnc_calls.py` contains examples of calling `strath`'s functions.
+In `demos/demo1_fnc_calls.py`, the functions convert paths and process `None`
+values.
 
 ```
 python demos/demo1_fnc_calls.py
 ```
 
-`demos/demo2_str_to_pathlib.py` contains a function that uses a `pathlib.Path`
-instance, but does not know its argument's type.
+In `demos/demo2_str_to_pathlib.py`, a function verifies that the path is a
+`pathlib.Path` instance.
 
 ```
 python demos/demo2_str_to_pathlib.py demos/the_planets.txt
 ```
 
-`demos/demo3_pathlib_to_str.py` contains a function that uses a string,
-but does not know its argument's type.
+In `demos/demo3_pathlib_to_str.py`, a function verifies that the path is a
+string.
 
 ```
 python demos/demo3_pathlib_to_str.py .. . .github/workflows demos strath tests

--- a/demos/demo1_fnc_calls.py
+++ b/demos/demo1_fnc_calls.py
@@ -24,10 +24,10 @@ def _print_path_and_type(message: str, some_path: str | Path) -> None:
 
 
 def _test_none_path(
-		message: str,
-		tested_fnc: Callable[[Any | None, bool], Any | None],
-		is_none_allowed: bool
-	) -> None:
+	message: str,
+	tested_fnc: Callable[[Any | None, bool], Any | None],
+	is_none_allowed: bool
+) -> None:
 	print(message)
 	try:
 		none_path = tested_fnc(None, is_none_allowed)

--- a/demos/demo1_fnc_calls.py
+++ b/demos/demo1_fnc_calls.py
@@ -2,6 +2,10 @@ import os
 from pathlib import Path
 import sys
 
+from collections.abc import Callable
+from typing import Any
+
+
 repo_root = str(Path(__file__).resolve().parents[1])
 sys.path.insert(0, repo_root)
 from strath import\
@@ -21,12 +25,12 @@ def _print_path_and_type(message: str, some_path: str | Path) -> None:
 
 def _test_none_path(
 		message: str,
-		fnc, # function
+		tested_fnc: Callable[[Any | None, bool], Any | None],
 		is_none_allowed: bool
 	) -> None:
 	print(message)
 	try:
-		none_path = fnc(None, is_none_allowed)
+		none_path = tested_fnc(None, is_none_allowed)
 		print(f"Returned value: {none_path}")
 	except TypeError:
 		print("TypeError raised")

--- a/demos/demo1_fnc_calls.py
+++ b/demos/demo1_fnc_calls.py
@@ -15,7 +15,7 @@ _TITLE_PATH1: str = "Path 1"
 _TITLE_PATH2: str = "Path 2"
 
 
-def _print_path_and_type(message: str, some_path: Path | str) -> None:
+def _print_path_and_type(message: str, some_path: str | Path) -> None:
 	print(f"{message}: {some_path} {type(some_path)}")
 
 

--- a/demos/demo2_str_to_pathlib.py
+++ b/demos/demo2_str_to_pathlib.py
@@ -8,7 +8,7 @@ sys.path.remove(repo_root)
 del repo_root
 
 
-def _print_file_content(file_path: Path | str) -> None:
+def _print_file_content(file_path: str | Path) -> None:
 	# The type of file_path is uncertain.
 	file_path: Path = ensure_path_is_pathlib(file_path, False)
 	# We know file_path is a pathlib.Path instance.

--- a/demos/demo2_str_to_pathlib.py
+++ b/demos/demo2_str_to_pathlib.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 
+
 repo_root = str(Path(__file__).resolve().parents[1])
 sys.path.insert(0, repo_root)
 from strath import ensure_path_is_pathlib

--- a/demos/demo3_pathlib_to_str.py
+++ b/demos/demo3_pathlib_to_str.py
@@ -8,7 +8,7 @@ sys.path.remove(repo_root)
 del repo_root
 
 
-def _sys_path_contains(dir_path: Path | str) -> bool:
+def _sys_path_contains(dir_path: str | Path) -> bool:
 	# The type of dir_path is uncertain.
 	dir_path: str = ensure_path_is_str(dir_path, False)
 	# We know dir_path is a string.

--- a/demos/demo3_pathlib_to_str.py
+++ b/demos/demo3_pathlib_to_str.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 
+
 repo_root = str(Path(__file__).resolve().parents[1])
 sys.path.insert(0, repo_root)
 from strath import ensure_path_is_str

--- a/strath/strath.py
+++ b/strath/strath.py
@@ -15,9 +15,9 @@ def _raise_type_error(is_none_allowed: bool) -> None:
 
 
 def ensure_path_is_pathlib(
-		some_path: str | Path | None,
-		is_none_allowed: bool
-	) -> Path | None:
+	some_path: str | Path | None,
+	is_none_allowed: bool
+) -> Path | None:
 	"""
 	If argument some_path is a string, this function converts it to a
 	pathlib.Path instance, which it returns. If some_path is a pathlib.Path
@@ -54,9 +54,9 @@ def ensure_path_is_pathlib(
 
 
 def ensure_path_is_str(
-		some_path: str | Path | None,
-		is_none_allowed: bool
-	) -> str | None:
+	some_path: str | Path | None,
+	is_none_allowed: bool
+) -> str | None:
 	"""
 	If argument some_path is a pathlib.Path instance, this function converts
 	it to a string, which it returns. If some_path is a string, this function

--- a/tests/test_strath.py
+++ b/tests/test_strath.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import sys
 
+
 repo_root = str(Path(__file__).resolve().parents[1])
 sys.path.insert(0, repo_root)
 from strath import\


### PR DESCRIPTION
* Consistent path annotations: `Path | str` -> `str | Path`.
* Parameter `tested_fnc` of function `_test_none_path` annotated as a `Callable`.
* The indentation of function signatures on more than one line was corrected.
* `README`: better description of the demos.

Close #15